### PR TITLE
Mapping ontologies from SEMIC Core Business Vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# kbo_leds
+# KBO Data processor
 Crossroads Bank for Enterprises published as LDES
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# KBO Data processor
+# [KBO](https://economie.fgov.be/en/themes/enterprises/crossroads-bank-enterprises) Data processor
 Crossroads Bank for Enterprises published as LDES
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# kbo_leds
+# pyldes_kbo
 Crossroads Bank for Enterprises published as LDES

--- a/app.py
+++ b/app.py
@@ -3,6 +3,9 @@ import argparse
 from rdflib import Graph, ORG, FOAF, SKOS
 from namespace.kbo import KBO
 from namespace.vcard import VCARD
+from namespace.locn import LOCN
+from namespace.legal import LEGAL
+from namespace.termname import TERMNAME
 from pyldes_kbo.services.data_loader import DataLoader
 from pyldes_kbo.services.kbo_generator import KboGenerator
 
@@ -10,10 +13,10 @@ from pyldes_kbo.services.kbo_generator import KboGenerator
 Free geocoding: https://geocode.maps.co/
 example: https://geocode.maps.co/search?q=Ter+Voortlaan+26+2650+edegem+belgium
 """
-
+#Uses relative path
 VERSION = "KboOpenData_2022_11"
-DB_LOCATION = "/mnt/c/dev/imec-ldes/pyldes_kbo/data/kbo.db" 
-BASE_PATH='/mnt/c/dev/imec-ldes/pyldes_kbo/data' 
+DB_LOCATION = "data/kbo.db"
+BASE_PATH='data'
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run the KBO example.')
@@ -33,21 +36,29 @@ if __name__ == '__main__':
             graph.bind("org", ORG)
             graph.bind("foaf", FOAF)
             graph.bind("vcard", VCARD)
+            graph.bind("locn", LOCN)
+            graph.bind("legal", LEGAL)
+            graph.bind("terms", TERMNAME)
             enterprise.to_rdf(graph, with_blank_nodes=False)
             print(graph.serialize(format='turtle'))
             #print(f"Processing record {current_rec} of {total_records} [{current_rec/total_records*100:.2f}%]\r", end="")
             print(f"Processing record {current_rec} of {total_records} [{current_rec/total_records*100:.2f}%]")
     elif args.command == 'sample':
-        enterprise = KboGenerator(BASE_PATH, DB_LOCATION).one("0416.822.559")
+        enterprise = KboGenerator(BASE_PATH, DB_LOCATION).one("0414.881.767")
         graph = Graph()
-        
+
+        #bind kbo, org, foaf, vard prefix.
         graph.bind("kbo", KBO)
         graph.bind("org", ORG)
         graph.bind("foaf", FOAF)
         graph.bind("vcard", VCARD)
-        
+        graph.bind("locn",LOCN)
+        graph.bind("legal",LEGAL)
+        graph.bind("terms",TERMNAME)
+
         enterprise.to_rdf(graph, with_blank_nodes=False)
         ent_dict = enterprise.to_dict()
         #print(json.dumps(ent_dict, indent=4))
+        #print(ent_dict)
         print(graph.serialize(format='turtle'))
 

--- a/models/kbo_activity.py
+++ b/models/kbo_activity.py
@@ -1,5 +1,6 @@
 from rdflib import Graph, URIRef, Literal, BNode, RDF, ORG, FOAF, SKOS
 from pyldes_kbo.namespace.kbo import KBO
+from pyldes_kbo.namespace.legal import LEGAL
 from pyldes_kbo.models.kbo_base import KboBase
 from pyldes_kbo.models.kbo_code import KboCode
 
@@ -17,7 +18,8 @@ class KboActivity(KboBase):
         else:
             activity_ref = URIRef(f"{KBO._NS}{self.nace_version}_{self.nace_code.code}")
         graph.add((activity_ref, RDF.type, KBO.Activity))
-        graph.add((activity_ref, KBO.naceCode, self.nace_code.to_rdf(graph, as_blank_node=as_blank_node)))
+        #add nace code
+        graph.add((activity_ref, LEGAL.companyActivity, self.nace_code.to_rdf(graph, as_blank_node=as_blank_node)))
         #graph.add((activity_ref, KBO.naceVersion, Literal(self.nace_version)))
         graph.add((activity_ref, KBO.classification, self.classification.to_rdf(graph, as_blank_node=as_blank_node)))
         return activity_ref

--- a/models/kbo_address.py
+++ b/models/kbo_address.py
@@ -2,6 +2,7 @@ from hashlib import blake2s
 from datetime import datetime
 from rdflib import Graph, URIRef, Literal, BNode, RDF, ORG, FOAF, SKOS
 from pyldes_kbo.namespace.kbo import KBO
+from pyldes_kbo.namespace.locn import LOCN
 from pyldes_kbo.namespace.vcard import VCARD
 from pyldes_kbo.models.kbo_base import KboBase
 from pyldes_kbo.models.kbo_code import KboCode
@@ -27,11 +28,11 @@ class KboAddress(KboBase):
             h.update(addr.encode("utf-8"))
             key = h.hexdigest()
             address_ref = URIRef(f"{KBO._NS}{key}")
-        graph.add((address_ref, RDF.type, VCARD.Address))
-        graph.add((address_ref, VCARD.postalCode, Literal(self.zip_code)))
-        graph.add((address_ref, VCARD.locality, Literal(self.municipality)))
-        graph.add((address_ref, VCARD.streetAddress, Literal(f"{self.street} {self.house_number}")))
-        graph.add((address_ref, VCARD.postOfficeBox, Literal(self.box)))
+        graph.add((address_ref, RDF.type, LOCN.Address))
+        graph.add((address_ref, LOCN.postCode, Literal(self.zip_code)))
+        graph.add((address_ref, LOCN.addressArea, Literal(self.municipality)))
+        graph.add((address_ref, LOCN.fullAddress, Literal(f"{self.street} {self.house_number}")))
+        graph.add((address_ref, LOCN.poBox, Literal(self.box)))
         address_type_ref = self.type_of_address.to_rdf(graph, as_blank_node=as_blank_node)
         graph.add((address_ref, KBO.addressType, address_type_ref))
         if self.date_striking_off:

--- a/models/kbo_enterprise.py
+++ b/models/kbo_enterprise.py
@@ -3,6 +3,9 @@ from typing import List
 from datetime import datetime
 from rdflib import Graph, URIRef, Literal, RDF, RDFS, ORG, SKOS
 from pyldes_kbo.namespace.kbo import KBO
+from pyldes_kbo.namespace.locn import LOCN
+from pyldes_kbo.namespace.legal import LEGAL
+from pyldes_kbo.namespace.termname import TERMNAME
 from pyldes_kbo.models.kbo_base import KboBase
 from pyldes_kbo.models.kbo_code import KboCode
 from pyldes_kbo.models.kbo_contact import KboContact
@@ -27,24 +30,25 @@ class KboEnterprise(KboBase):
         self.activities: List[KboActivity] = None
 
     def to_rdf(self, graph: Graph, version_object: bool = True, with_blank_nodes: bool = False) -> URIRef:
+
         enterprise_ref = URIRef(f"{KBO._NS}{self.enterprise_number.replace('.', '')}")
         status_ref = self.status.to_rdf(graph, as_blank_node=with_blank_nodes)
         juridical_situation_ref = self.juridical_situation.to_rdf(graph, as_blank_node=with_blank_nodes)
         juridical_form_ref = self.juridical_form.to_rdf(graph, as_blank_node=with_blank_nodes)
-        graph.add((enterprise_ref, RDF.type, ORG.Organization))
+        #graph.add((enterprise_ref, RDF.type, ORG.Organization))
         graph.add((enterprise_ref, RDF.type, KBO.Enterprise))
         graph.add((enterprise_ref, KBO.status, status_ref))
-        graph.add((enterprise_ref, KBO.juridicalForm, juridical_form_ref))
-        graph.add((enterprise_ref, KBO.juridicalSituation, juridical_situation_ref))
+        graph.add((enterprise_ref, LEGAL.companyType, juridical_form_ref))
+        graph.add((enterprise_ref, LEGAL.companyStatus, juridical_situation_ref))
         for denom in self.denominations:
             lang = denom.get_lang()
             if denom.type_of_denomination.code == "001":
-                graph.add((enterprise_ref, RDFS.label, Literal(denom.denomination, lang=lang)))
+                graph.add((enterprise_ref,LEGAL.legalName , Literal(denom.denomination, lang=lang)))
             if denom.type_of_denomination.code == "002":
-                graph.add((enterprise_ref, RDFS.label, Literal(denom.denomination, lang=lang)))
+                graph.add((enterprise_ref,LEGAL.legalName, Literal(denom.denomination, lang=lang)))
         for address in self.addresses:
             address_ref = address.to_rdf(graph, as_blank_node=with_blank_nodes)
-            graph.add((enterprise_ref, KBO.address, address_ref))
+            graph.add((enterprise_ref, LOCN.address, address_ref))
         for establishment in self.establishments:
             establishment_ref = establishment.to_rdf(graph, as_blank_node=with_blank_nodes)
             graph.add((enterprise_ref, KBO.establishment, establishment_ref))

--- a/models/kbo_establishment.py
+++ b/models/kbo_establishment.py
@@ -1,6 +1,8 @@
 from typing import List
 from datetime import datetime
 from rdflib import Graph, URIRef, Literal, BNode, RDF, ORG, FOAF, SKOS
+from pyldes_kbo.namespace.termname import TERMNAME
+from pyldes_kbo.namespace.locn import LOCN
 from pyldes_kbo.models.kbo_base import KboBase
 from pyldes_kbo.models.kbo_address import KboAddress
 from pyldes_kbo.models.kbo_contact import KboContact
@@ -23,10 +25,10 @@ class KboEstablishment(KboBase):
             establihment_ref = URIRef(f"{KBO._NS}{self.estblishment_number.replace('.', '')}")
         graph.add((establihment_ref, RDF.type, ORG.Site))
         graph.add((establihment_ref, RDF.type, KBO.Establishment))
-        graph.add((establihment_ref, KBO.startDate, Literal(self.start_date)))
+        graph.add((establihment_ref, TERMNAME.issued, Literal(self.start_date)))
         for address in self.addresses:
             addr_ref = address.to_rdf(graph, as_blank_node=as_blank_node)
-            graph.add((establihment_ref, KBO.address, addr_ref))
+            graph.add((establihment_ref, LOCN.Address, addr_ref))
         for contact in self.contacts:
             contact.load_entity_contact(graph, establihment_ref)
         return establihment_ref

--- a/namespace/kbo.py
+++ b/namespace/kbo.py
@@ -13,7 +13,15 @@ class KBO(DefinedNamespace):
     # properties
     activity: URIRef
     classification: URIRef
-    address: URIRef 
+    address: URIRef
+
+    # TypeOfAddress indicates the address type:
+    # Code Description
+    # REGO Address of the main office
+    # NOAD No data available for reasons of privacy protection
+    # BAET Address of the establishment unit
+    # ABBR Address of the branch in Belgium
+
     addressType: URIRef
     codeDescription: URIRef
     codeValue: URIRef
@@ -27,5 +35,4 @@ class KBO(DefinedNamespace):
     naceVersion: URIRef
     startDate: URIRef
     status: URIRef
-
     _NS = Namespace("https://kbopub.economie.fgov.be/kbo#")

--- a/namespace/legal.py
+++ b/namespace/legal.py
@@ -1,0 +1,31 @@
+from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
+
+
+###
+# created from ISA Programme Location Core Vocabulary
+#  https://www.w3.org/ns/locn
+##
+class LEGAL(DefinedNamespace):
+
+    # classes
+
+    #property
+    # The name under which the Legal Entity is legally registered
+    legalName:URIRef
+    legalIdentifier:URIRef
+    #This is a general term that encompasses all the economic activities carried out by a company during the course of business.
+    #The activity of a company should be recorded using a controlled vocabulary. Several such vocabularies exist,
+    #many of which map to the UN's ISIC codes. Where a particular controlled vocabulary is in use within a given context,
+    #such as SIC codes in the UK, it is acceptable to use these, however,
+    #the preferred choice for European interoperability is NACE.
+    companyActivity:URIRef
+
+    # The classification of the Legal Entity as a member of a particular group in the context of legal registration.
+    companyType:URIRef
+
+    # Information about the viability of the current position of the legal entity.
+    companyStatus:URIRef
+
+    registeredAddress:URIRef
+    _NS = Namespace("http://www.w3.org/ns/legal#")

--- a/namespace/locn.py
+++ b/namespace/locn.py
@@ -1,0 +1,47 @@
+from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
+
+
+###
+# created from ISA Programme Location Core Vocabulary
+#  https://www.w3.org/ns/locn
+##
+class LOCN(DefinedNamespace):
+
+    # classes
+    Location:URIRef
+    Address:URIRef
+    Geometry:URIRef
+
+    #property
+
+    # Id of the address
+    addressId: URIRef
+    #The locn:address property relationship associates any resource with the locn:Address class
+    address:URIRef
+    # The name or names of a geographic area or locality that groups a number of addressable objects for addressing purposes, without being an administrative unit. This would typically be part of a city, a neighbourhood or village. The domain of locn:addressArea is locn:Address.
+    addressArea: URIRef
+    #The complete address written as a string, with or without formatting. The domain of locn:fullAddress is locn:Address.
+    fullAddress:URIRef
+
+    # administrativeUnitLevel1 (country)
+    adminUnitL1: URIRef
+    # administrativeUnitLevel2(country / region / state)
+    adminUnitL2: URIRef
+
+    #The Post Office Box number. The domain of locn:poBox is locn:Address.
+    poBox:URIRef
+    postName: URIRef
+    #The Post Office Box number. The domain of locn:poBox is locn:Address.
+    postCode:URIRef
+
+    #plot the area.
+    geometry:URIRef
+
+    #locator Designator
+    locatorDesignator:URIRef
+    #locatorName
+    locatorName:URIRef
+    #The name of a passage or way through from one location to another.
+    thoroughfare:URIRef
+    _NS = Namespace("https://www.w3.org/ns/locn#")

--- a/namespace/termname.py
+++ b/namespace/termname.py
@@ -1,0 +1,22 @@
+from rdflib.namespace import DefinedNamespace, Namespace
+from rdflib.term import URIRef
+
+
+###
+# created from ISA Programme Location Core Vocabulary
+#  https://www.w3.org/ns/locn
+##
+class TERMNAME(DefinedNamespace):
+
+    # property
+
+    # Some jurisdictions recognise concepts such as a trading name or alternative forms of a legal entity's name.
+    # The alternative name property can be used to record such names but should not be used to record translations of the primary legal name.
+    # Where more than one name exists and where they have equal standing but are expressed in different languages,
+    # identify the language used in each of the multiple names.
+    alternative:URIRef
+    identifier:URIRef
+    # The date on which the Identifier was assigned.
+    issued:URIRef
+
+    _NS = Namespace("http://purl.org/dc/terms/")

--- a/services/kbo_generator.py
+++ b/services/kbo_generator.py
@@ -20,6 +20,7 @@ class KboGenerator ():
         self.db_location = db_location
 
     def count(self) -> int:
+        print(self.db_location)
         conn = sqlite3.connect(self.db_location)
         cursor = conn.cursor()
         cursor.execute(f"SELECT COUNT(*) FROM enterprise")
@@ -45,6 +46,7 @@ class KboGenerator ():
         conn.close()
 
     def one(self, enterprise_nr:str) -> KboEnterprise:
+        # print(self.db_location)
         conn = sqlite3.connect(self.db_location)
         cursor = conn.cursor()
         cursor.execute(f"SELECT * FROM enterprise WHERE EnterpriseNumber=?", (enterprise_nr,))


### PR DESCRIPTION
Based on the following suggestions: 

Given the EU context it may be good to directly reuse the [SEMIC Core Business Vocabulary](https://eur02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fsemiceu.github.io%2FCore-Business-Vocabulary%2Freleases%2F2.00%2F&data=05%7C01%7CXueying.Deng%40imec.be%7Ce554fd89b1614600058308db1971b724%7Ca72d5a7225ee40f09bd1067cb5b770d4%7C0%7C0%7C638131748409665334%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=0FJbMKa37c0aGm%2BGJLjB5MRmVqepWcoPbYAjXVmyUT8%3D&reserved=0), which also reuses the ORG ontology + some other standard ones.

It is also good to use locn:geometry later to plot the area.